### PR TITLE
Add .flake8 configuration for code style enforcement

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503, E501
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    .tox,
+    build,
+    dist,
+    *.egg-info
+per-file-ignores =
+    __init__.py:F401
+    tests/*:S101,S106
+max-complexity = 10
+docstring-convention = google
+import-order-style = google


### PR DESCRIPTION
## Summary
- Introduces a new `.flake8` configuration file to enforce consistent code style
- Sets maximum line length to 88 characters
- Ignores specific warnings (E203, W503, E501) to align with project preferences
- Excludes common directories and files from linting
- Adds per-file ignores for `__init__.py` and test files
- Enforces a maximum code complexity of 10
- Specifies Google style for docstrings and import order

## Changes

### Configuration
- Created `.flake8` file with detailed linting rules:
  - `max-line-length` set to 88
  - `extend-ignore` includes E203, W503, E501
  - `exclude` lists common non-source directories and files
  - `per-file-ignores` for unused imports in `__init__.py` and logging/style issues in tests
  - `max-complexity` set to 10 to maintain code simplicity
  - `docstring-convention` and `import-order-style` set to Google style

## Test plan
- [x] Run flake8 linting to verify configuration is applied correctly
- [x] Confirm no linting errors in excluded directories
- [x] Validate that ignored errors are not reported
- [x] Ensure code complexity warnings trigger appropriately

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b53c383b-741b-438c-863a-e0b36e314f53

## Summary by Sourcery

Add a .flake8 config file to enforce consistent code style across the project

Enhancements:
- Set maximum line length to 88 characters
- Ignore E203, W503, and E501 errors to match project style
- Exclude common non-source directories and files from linting
- Add per-file ignores for unused imports in __init__.py and lint issues in test files
- Enforce a maximum code complexity of 10
- Apply Google style conventions for docstrings and import ordering